### PR TITLE
Implement basic functionality

### DIFF
--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -37,9 +37,11 @@ def lock(timestamp, input_data, code):
     code : str
         Path to analysis directory.
     """
-    hash_dict = ct.construct_dict(timestamp, input_data, code)
+    assert not os.path.exists(CATALOGUE_LOCK_PATH)
     if not os.path.exists(CATALOGUE_DIR):
         os.makedirs(CATALOGUE_DIR)
+        
+    hash_dict = ct.construct_dict(timestamp, input_data, code)
     with open(CATALOGUE_LOCK_PATH, "w") as f:
         json.dump(hash_dict, f)
 

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -21,6 +21,7 @@ def main():
         type=str,
         metavar='input_data',
         help=textwrap.dedent(""),
+        required=True,
         default=None)
 
     engage_parser.add_argument(
@@ -28,6 +29,7 @@ def main():
         type=str,
         metavar='input_data',
         help=textwrap.dedent(""),
+        required=True,
         default=None)
 
     checkhashes_parser = subparsers.add_parser("checkhashes", description="", help="")
@@ -44,6 +46,7 @@ def main():
         type=str,
         metavar='input_data',
         help=textwrap.dedent(""),
+        required=True,
         default=None)
 
     disengage_parser.add_argument(
@@ -51,6 +54,7 @@ def main():
         type=str,
         metavar='input_data',
         help=textwrap.dedent(""),
+        required=True,
         default=None)
 
     disengage_parser.add_argument(
@@ -58,6 +62,7 @@ def main():
         type=str,
         metavar='output_data',
         help=textwrap.dedent(""),
+        required=True,
         default=None)
 
     args = parser.parse_args()


### PR DESCRIPTION
Closes #10 
Closes #11 

The basic functionality is implemented:

1. When the user calls `catalogue engage` this create a `catalogue_files/.loc` file with hash of the timestamp, the input data and the code directories. 

2. When `catalogue disengage` is called, the `.loc` file is read, the retrieved hashes are compared with new hashes of the input data and code directories. 

3. If the check passed, a `catalogue_files/<TIMESTAMP>.json` file is created with the results. 

4. The result of the hash check is printed to the console.

Questions for reviews:
- are we happy with the output format or do we want to change it?
- any other design changes/preferences?