### PR TITLE
Search parent dir in git repo checks

### DIFF
--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -175,7 +175,7 @@ def hash_code(repo_path):
     """
 
     try:
-        repo = git.Repo(repo_path)
+        repo = git.Repo(repo_path, search_parent_directories=True)
     except InvalidGitRepositoryError:
         raise InvalidGitRepositoryError("provided code directory is not a valid git repository")
 

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -41,7 +41,7 @@ def git_query(repo_path, commit_changes=False):
     """
 
     try:
-        repo = git.Repo(repo_path)
+        repo = git.Repo(repo_path, search_parent_directories=True)
     except InvalidGitRepositoryError:
         raise InvalidGitRepositoryError("provided code directory is not a valid git repository")
 
@@ -85,7 +85,7 @@ def lock(timestamp, input_data, code):
     assert not os.path.exists(CATALOGUE_LOCK_PATH)
     if not os.path.exists(CATALOGUE_DIR):
         os.makedirs(CATALOGUE_DIR)
-        
+
     hash_dict = ct.construct_dict(timestamp, input_data, code)
     with open(CATALOGUE_LOCK_PATH, "w") as f:
         json.dump(hash_dict, f)


### PR DESCRIPTION
When we check for git repository the `code` directory is used as `repo_path`.

However, if my analysis repo has the following structure:

```
├── project/
│   ├── data/
│   ├── code/
│   └── results/ 
```

and I call `catalogue engage --code code`, I get a `git.exc.InvalidGitRepositoryError: provided code directory is not a valid git repository`. 

Adding the `search_parent_directory` flag when instantiating the `git.Repo()` object fixes this.