### PR TITLE
Feature/compare

### DIFF
--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -4,7 +4,7 @@ import hashlib
 import git
 from git import InvalidGitRepositoryError, RepositoryDirtyError
 
-def hash_file(filepath, m=hashlib.sha512()):
+def hash_file(filepath, m=None):
     '''
     Hash the contents of a file
 
@@ -12,13 +12,17 @@ def hash_file(filepath, m=hashlib.sha512()):
     ----------
     filepath : str
         A string pointing to the file you want to hash
-    m : hashlib hash object, optional
+    m : hashlib hash object, optional (default is None to create a new object)
         hash_file updates m with the contents of filepath and returns m
 
     Returns
     -------
     hashlib hash object
     '''
+
+    if m is None:
+        m = hashlib.sha512()
+
     with open(filepath, 'rb') as f:
         # The following construction lets us read f in chunks,
         # instead of loading an arbitrary file in all at once.

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -1,13 +1,31 @@
 from . import catalogue as ct
+from .engage import create_timestamp
 
-def compare(*args):
+def compare(args):
     """
-    TODO: IMPLEMENT!
+    Compares two hash files
+
+    Compares two hash files, given as input arguments to the command line tool. Prints results
+    on the command line.
     """
-    pass
+
+    hash_dict_1 = ct.load_hash(args.hashes[0])
+    hash_dict_2 = ct.load_hash(args.hashes[1])
+
+    print(compare_hashes(hash_dict_1, hash_dict_2))
 
 def check_hashes(args):
-    pass
+    """
+    Checks hash against results
+
+    Checks the values in a provided hash file with the results from hashing the provided locations
+    (input_data, code, and output_data) in the input arguments. Prints results on the command line
+    """
+
+    hash_dict_1 = ct.load_hash(args.hashes)
+    hash_dict_2 = ct.construct_dict(create_timestamp(), args.input_data, args.code, args.output_data, "disengage")
+
+    print(compare_hashes(hash_dict_1, hash_dict_2))
 
 def compare_hashes(hash_dict_1, hash_dict_2):
     """

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -6,47 +6,76 @@ def compare(*args):
     """
     pass
 
-# def checkhashes(args):
-#     pass
-
 def check_hashes(args):
+    pass
+
+def compare_hashes(hash_dict_1, hash_dict_2):
+    """
+    Compare two hash dictionaries
+
+    Compare two hash dictionaries. Returns a string summarizing the matches (when two hashes are
+    identical), differences (when a hash has been computed for the same entity twice and they
+    are different), and failures (when an entry only exists in one of the two hash dictionaries).
+
+    Parameters
+    ----------
+    hash_dict_1: dict { str : dict }
+        First hash dictionary
+    hash_dict_2: dict { str : dict }
+        Second has dictionary
+
+    Returns
+    -------
+    str
+    """
+
     get_h = lambda x: list(x.values())[0]
-    hash_dict = ct.load_hash(args.filepath)
     failures = []
     matches = []
     differs = []
-    if args.input_data:
+
+    for key in ["timestamp", "input_data", "code"]:
         try:
-            input1 = get_h(hash_dict["input_data"])
-        except:
-            failures.append("input_data")
-        if get_h(ct.hash_input(args.input_data)) == input1:
-            matches.append("input_data")
+            entry_1 = get_h(hash_dict_1[key])
+            entry_2 = get_h(hash_dict_2[key])
+        except KeyError:
+            failures.append(key)
+
+        if entry_1 == entry_2:
+            matches.append(key)
         else:
-            differs.append("input_data")
-    if args.code:
-        try:
-            code1 = get_h(hash_dict["code"])
-        except:
-            failures.append("code")
-        if get_h(ct.hash_code(args.code)) == code1:
-            matches.append("code")
-        else:
-            differs.append("code")
-    if args.output_data:
-        try:
-            output1 = hash_dict["output_data"]
-        except:
-            failures.append("output_data")
-        output2 = hash_output(args.output_data)
-        n = min(len(output1, output2))
-        for i in range(n):
-            a, b, c = ct.compare_folders(output1[i], output2[i])
-            failures.extend(a)
-            matches.extend(b)
-            differs.extend(c)
-        else:
-            differs.append("timestamp")
+            differs.append(key)
+
+    try:
+        output_1 = get_h(hash_dict_1["output_data"])
+    except KeyError:
+        output_1 = None
+
+    try:
+        output_2 = get_h(hash_dict_2["output_data"])
+    except KeyError:
+        output_2 = None
+
+    # if one or both accesses failed, append to failures
+    if output_1 is None and output_2 is None:
+        failures.append("output_data")
+    elif output_1 is None:
+        failures.extend(output_2.keys())
+    elif output_2 is None:
+        failures.extend(output_1.keys())
+    else:
+        # both accesses succeeded, check each unique file
+        all_outputs = list(output_1.keys() | output_2.keys()) # union of two dict_keys objects converted to list
+
+        for out_file in all_outputs:
+            try:
+                if output_1[out_file] == output_2[out_file]:
+                    matches.append(out_file)
+                else:
+                    differs.append(out_file)
+            except KeyError:
+                failures.append(out_file)
+
     return "\n".join([
         "results differ in {} places:".format(len(differs)),
         "===========================",

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -52,8 +52,33 @@ def main():
     checkhashes_parser = subparsers.add_parser("checkhashes", description="", help="")
     checkhashes_parser.set_defaults(func=check_hashes)
 
+    checkhashes_parser.add_argument("--hashes", type=str, metavar="hashes", help="")
+
+    checkhashes_parser.add_argument(
+        '--input_data',
+        type=str,
+        metavar='input_data',
+        help=textwrap.dedent(""),
+        default="data")
+
+    checkhashes_parser.add_argument(
+        '--code',
+        type=str,
+        metavar='code',
+        help=textwrap.dedent(""),
+        default=".")
+
+    checkhashes_parser.add_argument(
+        '--output_data',
+        type=str,
+        metavar='output_data',
+        help=textwrap.dedent(""),
+        default="results")
+
     compare_parser = subparsers.add_parser("compare", description="", help="")
     compare_parser.set_defaults(func=compare)
+
+    compare_parser.add_argument("hashes", type=str, nargs=2, help="")
 
     disengage_parser = subparsers.add_parser("disengage", description="", help="")
     disengage_parser.set_defaults(func=disengage)


### PR DESCRIPTION
Implements comparisons between hashes and ability to check hashes against the current state. Implements #3, #26, #29, and fixes #28.

* Implements a `compare_hashes` function to work as desired for both the `compare` and `check_hashes` options
* Implements `compare` and `check_hashes`
* Adds input argument parsing for `compare` and `checkhashes`
* Fixes a bug in the `hash_file` function that I uncovered while testing the above functionality.