### PR TITLE
Refactor

### DIFF
--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -189,7 +189,7 @@ def hash_code(repo_path):
     return repo.head.commit.hexsha
 
 
-def construct_dict(timestamp, input_data, code, output_data=None, mode="engage"):
+def construct_dict(timestamp, args):
     """
     Create dictionary with hashes of input files.
 
@@ -197,14 +197,8 @@ def construct_dict(timestamp, input_data, code, output_data=None, mode="engage")
     ----------
     timestamp : str
         Datetime.
-    input_data : str
-        Path to input data directory.
-    code : str
-        Path to analysis directory.
-    output_data : str
-        Path to analysis results directory.
-    mode : str
-        Either of engage/disengage. Indicates what mode catalogue tool is in.
+    args : obj
+        Command line input arguments (argparse.Namespace).
 
     Returns
     -------
@@ -213,18 +207,18 @@ def construct_dict(timestamp, input_data, code, output_data=None, mode="engage")
     """
     results = {
         "timestamp": {
-            mode: timestamp
+            args.command: timestamp
         },
         "input_data": {
-            input_data : hash_input(input_data)
+            args.input_data : hash_input(args.input_data)
         },
         "code": {
-            code : hash_code(code)
+            args.code : hash_code(args.code)
         }
     }
-    if output_data is not None:
+    if hasattr(args, 'output_data'):
         results["output_data"] = {}
-        results["output_data"].update({output_data : hash_output(output_data)})
+        results["output_data"].update({args.output_data : hash_output(args.output_data)})
     return results
 
 

--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -4,7 +4,7 @@ import hashlib
 import git
 from git import InvalidGitRepositoryError, RepositoryDirtyError
 
-def hash_file(filepath, m=hashlib.sha512()):
+def hash_file(filepath, m=None):
     '''
     Hash the contents of a file
 
@@ -12,13 +12,17 @@ def hash_file(filepath, m=hashlib.sha512()):
     ----------
     filepath : str
         A string pointing to the file you want to hash
-    m : hashlib hash object, optional
+    m : hashlib hash object, optional (default is None to create a new object)
         hash_file updates m with the contents of filepath and returns m
 
     Returns
     -------
     hashlib hash object
     '''
+
+    if m is None:
+        m = hashlib.sha512()
+
     with open(filepath, 'rb') as f:
         # The following construction lets us read f in chunks,
         # instead of loading an arbitrary file in all at once.

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -23,7 +23,7 @@ def check_hashes(args):
     """
 
     hash_dict_1 = ct.load_hash(args.hashes)
-    hash_dict_2 = ct.construct_dict(create_timestamp(), args.input_data, args.code, args.output_data, "disengage")
+    hash_dict_2 = ct.construct_dict(create_timestamp(), args) 
 
     print(compare_hashes(hash_dict_1, hash_dict_2))
 

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -1,13 +1,31 @@
 from . import catalogue as ct
+from .engage import create_timestamp
 
-def compare(*args):
+def compare(args):
     """
-    TODO: IMPLEMENT!
+    Compares two hash files
+
+    Compares two hash files, given as input arguments to the command line tool. Prints results
+    on the command line.
     """
-    pass
+
+    hash_dict_1 = ct.load_hash(args.hashes[0])
+    hash_dict_2 = ct.load_hash(args.hashes[1])
+
+    print(compare_hashes(hash_dict_1, hash_dict_2))
 
 def check_hashes(args):
-    pass
+    """
+    Checks hash against results
+
+    Checks the values in a provided hash file with the results from hashing the provided locations
+    (input_data, code, and output_data) in the input arguments. Prints results on the command line
+    """
+
+    hash_dict_1 = ct.load_hash(args.hashes)
+    hash_dict_2 = ct.construct_dict(create_timestamp(), args.input_data, args.code, args.output_data, "disengage")
+
+    print(compare_hashes(hash_dict_1, hash_dict_2))
 
 def compare_hashes(hash_dict_1, hash_dict_2):
     """

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -1,5 +1,5 @@
 from . import catalogue as ct
-from .engage import create_timestamp
+from .utils import create_timestamp
 
 def compare(args):
     """
@@ -23,7 +23,7 @@ def check_hashes(args):
     """
 
     hash_dict_1 = ct.load_hash(args.hashes)
-    hash_dict_2 = ct.construct_dict(create_timestamp(), args) 
+    hash_dict_2 = ct.construct_dict(create_timestamp(), args)
 
     print(compare_hashes(hash_dict_1, hash_dict_2))
 

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -6,47 +6,76 @@ def compare(*args):
     """
     pass
 
-# def checkhashes(args):
-#     pass
-
 def check_hashes(args):
+    pass
+
+def compare_hashes(hash_dict_1, hash_dict_2):
+    """
+    Compare two hash dictionaries
+
+    Compare two hash dictionaries. Returns a string summarizing the matches (when two hashes are
+    identical), differences (when a hash has been computed for the same entity twice and they
+    are different), and failures (when an entry only exists in one of the two hash dictionaries).
+
+    Parameters
+    ----------
+    hash_dict_1: dict { str : dict }
+        First hash dictionary
+    hash_dict_2: dict { str : dict }
+        Second has dictionary
+
+    Returns
+    -------
+    str
+    """
+
     get_h = lambda x: list(x.values())[0]
-    hash_dict = ct.load_hash(args.filepath)
     failures = []
     matches = []
     differs = []
-    if args.input_data:
+
+    for key in ["timestamp", "input_data", "code"]:
         try:
-            input1 = get_h(hash_dict["input_data"])
-        except:
-            failures.append("input_data")
-        if get_h(ct.hash_input(args.input_data)) == input1:
-            matches.append("input_data")
+            entry_1 = get_h(hash_dict_1[key])
+            entry_2 = get_h(hash_dict_2[key])
+        except KeyError:
+            failures.append(key)
+
+        if entry_1 == entry_2:
+            matches.append(key)
         else:
-            differs.append("input_data")
-    if args.code:
-        try:
-            code1 = get_h(hash_dict["code"])
-        except:
-            failures.append("code")
-        if get_h(ct.hash_code(args.code)) == code1:
-            matches.append("code")
-        else:
-            differs.append("code")
-    if args.output_data:
-        try:
-            output1 = hash_dict["output_data"]
-        except:
-            failures.append("output_data")
-        output2 = hash_output(args.output_data)
-        n = min(len(output1, output2))
-        for i in range(n):
-            a, b, c = ct.compare_folders(output1[i], output2[i])
-            failures.extend(a)
-            matches.extend(b)
-            differs.extend(c)
-        else:
-            differs.append("timestamp")
+            differs.append(key)
+
+    try:
+        output_1 = get_h(hash_dict_1["output_data"])
+    except KeyError:
+        output_1 = None
+
+    try:
+        output_2 = get_h(hash_dict_2["output_data"])
+    except KeyError:
+        output_2 = None
+
+    # if one or both accesses failed, append to failures
+    if output_1 is None and output_2 is None:
+        failures.append("output_data")
+    elif output_1 is None:
+        failures.extend(output_2.keys())
+    elif output_2 is None:
+        failures.extend(output_1.keys())
+    else:
+        # both accesses succeeded, check each unique file
+        all_outputs = list(output_1.keys() | output_2.keys()) # union of two dict_keys objects converted to list
+
+        for out_file in all_outputs:
+            try:
+                if output_1[out_file] == output_2[out_file]:
+                    matches.append(out_file)
+                else:
+                    differs.append(out_file)
+            except KeyError:
+                failures.append(out_file)
+
     return "\n".join([
         "results differ in {} places:".format(len(differs)),
         "===========================",

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -6,7 +6,7 @@ from git import InvalidGitRepositoryError
 
 from . import catalogue as ct
 from .compare import compare_hashes
-from .utils import create_timestamp
+from .utils import create_timestamp, check_paths_exists
 
 CATALOGUE_DIR = "catalogue_results"
 CATALOGUE_LOCK_PATH = os.path.join(CATALOGUE_DIR, ".lock")
@@ -70,6 +70,8 @@ def git_query(repo_path, commit_changes=False):
 
 
 def engage(args):
+    assert check_paths_exists(args), 'Not all provided filepaths exist.'
+
     if git_query(args.code, True):
         try:
             assert not os.path.exists(CATALOGUE_LOCK_PATH)
@@ -87,6 +89,8 @@ def engage(args):
 
 
 def disengage(args):
+    assert check_paths_exists(args), 'Not all provided filepaths exist.'
+
     timestamp = create_timestamp()
     try:
         lock_dict = ct.load_hash(CATALOGUE_LOCK_PATH)

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -75,7 +75,7 @@ def engage(args):
     if git_query(args.code, True):
         try:
             assert not os.path.exists(CATALOGUE_LOCK_PATH)
-        except:
+        except AssertionError:
             print("Already engaged (.lock file exists). To disengage run 'catalogue disengage...'")
             print("See 'catalogue disengage --help' for details")
         else:

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -80,7 +80,12 @@ def lock(timestamp, args):
     args : obj
         Command line input arguments (argparse.Namespace).
     """
-    assert not os.path.exists(CATALOGUE_LOCK_PATH)
+    try:
+        assert not os.path.exists(CATALOGUE_LOCK_PATH)
+    except:
+        print("Already engaged. To disengage run 'catalogue disengage...'")
+        print("See 'catalogue disengage --help' for details")
+
     if not os.path.exists(CATALOGUE_DIR):
         os.makedirs(CATALOGUE_DIR)
 
@@ -161,12 +166,8 @@ def create_timestamp():
 
 def engage(args):
     if git_query(args.code, True):
-        try:
-            lock(create_timestamp(), args)
-            print("'catalogue engage' succeeded. Proceed with analysis")
-        except:
-            print("Already engaged. To disengage run 'catalogue disengage...'")
-            print("See 'catalogue disengage --help' for details")
+        lock(create_timestamp(), args)
+        print("'catalogue engage' succeeded. Proceed with analysis")
 
 
 def disengage(args):

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -5,8 +5,8 @@ import git
 from git import InvalidGitRepositoryError
 
 from . import catalogue as ct
-
-from datetime import datetime
+from .compare import compare_hashes
+from .utils import create_timestamp
 
 CATALOGUE_DIR = "catalogue_results"
 CATALOGUE_LOCK_PATH = os.path.join(CATALOGUE_DIR, ".lock")
@@ -158,10 +158,6 @@ def check_against_lock(dict1, dict2):
         msg_code,
         "==========================="]
         )
-
-
-def create_timestamp():
-    return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
 def engage(args):

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -42,7 +42,7 @@ def main():
         type=str,
         metavar='input_data',
         help=textwrap.dedent("This argument should be the path (full or relative) to the directory" +
-                             " containint the input data. Default value is data"),
+                             " containing the input data. Default value is data."),
         default='data')
 
     common_parser.add_argument(
@@ -59,7 +59,8 @@ def main():
         '--output_data',
         type=str,
         metavar='output_data',
-        help=textwrap.dedent(""),
+        help=textwrap.dedent("This argument should be the path (full or relative) to the directory" +
+                             " containing the analysis output data. Default value is results."),
         default="results")
 
     # create subparsers

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -22,6 +22,14 @@ def main():
     current working directory) for the input data argument, and the current directory
     for the code. The code argument must be a git repository, or a directory whose
     parent directory contains a git repository.
+
+    disengage
+    ---------
+    When running in `disengage` mode, three options can be set: `--input_data`, `--code`
+    and `output_data`. The meaning and defaults for `--input_data` and `code` are the
+    same as when in `engage` mode (see above). The `output_data` argument should also
+    be a string, specifying the directory with the analysis results. The default for
+    the `output_data` argument is `"results"` (relative to the current working directory).
     """
     parser = argparse.ArgumentParser(
         description="",

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -52,8 +52,33 @@ def main():
     checkhashes_parser = subparsers.add_parser("checkhashes", description="", help="")
     checkhashes_parser.set_defaults(func=check_hashes)
 
+    checkhashes_parser.add_argument("--hashes", type=str, metavar="hashes", help="")
+
+    checkhashes_parser.add_argument(
+        '--input_data',
+        type=str,
+        metavar='input_data',
+        help=textwrap.dedent(""),
+        default="data")
+
+    checkhashes_parser.add_argument(
+        '--code',
+        type=str,
+        metavar='code',
+        help=textwrap.dedent(""),
+        default=".")
+
+    checkhashes_parser.add_argument(
+        '--output_data',
+        type=str,
+        metavar='output_data',
+        help=textwrap.dedent(""),
+        default="results")
+
     compare_parser = subparsers.add_parser("compare", description="", help="")
     compare_parser.set_defaults(func=compare)
+
+    compare_parser.add_argument("hashes", type=str, nargs=2, help="")
 
     disengage_parser = subparsers.add_parser("disengage", description="", help="")
     disengage_parser.set_defaults(func=disengage)

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -27,7 +27,7 @@ def main():
         description="",
         formatter_class=argparse.RawTextHelpFormatter)
 
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest="command")
 
     engage_parser = subparsers.add_parser("engage", description="", help="")
     engage_parser.set_defaults(func=engage)

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -35,12 +35,9 @@ def main():
         description="",
         formatter_class=argparse.RawTextHelpFormatter)
 
-    subparsers = parser.add_subparsers(dest="command")
-
-    engage_parser = subparsers.add_parser("engage", description="", help="")
-    engage_parser.set_defaults(func=engage)
-
-    engage_parser.add_argument(
+    # declare shared arguments here
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument(
         '--input_data',
         type=str,
         metavar='input_data',
@@ -48,7 +45,7 @@ def main():
                              " containint the input data. Default value is data"),
         default='data')
 
-    engage_parser.add_argument(
+    common_parser.add_argument(
         '--code',
         type=str,
         metavar='code',
@@ -57,60 +54,36 @@ def main():
                              " that is a git repository. Default is the current working directory."),
         default='.')
 
-    checkhashes_parser = subparsers.add_parser("checkhashes", description="", help="")
-    checkhashes_parser.set_defaults(func=check_hashes)
-
-    checkhashes_parser.add_argument("--hashes", type=str, metavar="hashes", help="")
-
-    checkhashes_parser.add_argument(
-        '--input_data',
-        type=str,
-        metavar='input_data',
-        help=textwrap.dedent(""),
-        default="data")
-
-    checkhashes_parser.add_argument(
-        '--code',
-        type=str,
-        metavar='code',
-        help=textwrap.dedent(""),
-        default=".")
-
-    checkhashes_parser.add_argument(
+    output_parser = argparse.ArgumentParser(add_help=False)
+    output_parser.add_argument(
         '--output_data',
         type=str,
         metavar='output_data',
         help=textwrap.dedent(""),
         default="results")
+
+    # create subparsers
+    subparsers = parser.add_subparsers(dest="command")
+
+    engage_parser = subparsers.add_parser(
+        "engage", parents=[common_parser], description="", help=""
+    )
+    engage_parser.set_defaults(func=engage)
+
+    checkhashes_parser = subparsers.add_parser(
+        "checkhashes", parents=[common_parser, output_parser], description="", help=""
+    )
+    checkhashes_parser.set_defaults(func=check_hashes)
+    checkhashes_parser.add_argument("--hashes", type=str, metavar="hashes", help="")
 
     compare_parser = subparsers.add_parser("compare", description="", help="")
     compare_parser.set_defaults(func=compare)
-
     compare_parser.add_argument("hashes", type=str, nargs=2, help="")
 
-    disengage_parser = subparsers.add_parser("disengage", description="", help="")
+    disengage_parser = subparsers.add_parser(
+        "disengage", parents=[common_parser, output_parser], description="", help=""
+    )
     disengage_parser.set_defaults(func=disengage)
-
-    disengage_parser.add_argument(
-        '--input_data',
-        type=str,
-        metavar='input_data',
-        help=textwrap.dedent(""),
-        default="data")
-
-    disengage_parser.add_argument(
-        '--code',
-        type=str,
-        metavar='code',
-        help=textwrap.dedent(""),
-        default=".")
-
-    disengage_parser.add_argument(
-        '--output_data',
-        type=str,
-        metavar='output_data',
-        help=textwrap.dedent(""),
-        default="results")
 
     args = parser.parse_args()
     args.func(args)

--- a/catalogue/utils.py
+++ b/catalogue/utils.py
@@ -1,0 +1,6 @@
+
+from datetime import datetime
+
+
+def create_timestamp():
+    return datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/catalogue/utils.py
+++ b/catalogue/utils.py
@@ -10,9 +10,17 @@ def create_timestamp():
 
 def check_paths_exists(args):
     """
-    Check whether all provided paths to catalogue exist.
+    Check whether all filepaths provided to catalogue exist.
+
+    Parameters:
+    ------------
+    args : obj
+        Command line input arguments (argparse.Namespace).
+
+    Returns:
+    ---------
+    Boolean indicating if all filepaths exist.
     """
-    attributes = vars(args)
-    inputs = [arg for arg in attributes if arg not in ["command", "func"]]
-    path_checks = [os.path.exists(attributes[i]) for i in inputs]
+    paths = [value for key, value in vars(args).items() if key not in ["command", "func"]]
+    path_checks = [os.path.exists(path) for path in paths]
     return all(path_checks)

--- a/catalogue/utils.py
+++ b/catalogue/utils.py
@@ -1,6 +1,18 @@
 
+import os
+
 from datetime import datetime
 
 
 def create_timestamp():
     return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def check_paths_exists(args):
+    """
+    Check whether all provided paths to catalogue exist.
+    """
+    attributes = vars(args)
+    inputs = [arg for arg in attributes if arg not in ["command", "func"]]
+    path_checks = [os.path.exists(attributes[i]) for i in inputs]
+    return all(path_checks)


### PR DESCRIPTION
Closes #27 
Closes #25 
Closes #23

Summary:
- removed `lock()` and `unlock()`, all functionality now in `engage()`/`disengage()` with better error handling 
- deleted `check_against_lock()` and `check_hashes()` from `engage.py`, use `compare_hashes()` from `compare.py` instead
- cleaned up `parser.py` by combining common args to avoid duplication
- parser now saves which catalogue `command` was called (engage, disengage...)
- cleaned up `construct_dict` to have params `(timestamp, args)` instead of `(timestamp, input_data, code, ...)` and use `args.command` instead of the hardcoded `mode` flag

Questions on `disengage()` implementation:
- We delete the `.lock` file right after it is read - this is consistent with what is described in the README. Should the file only be deleted at the end of the function, once all the steps have completed successfully?  (line 93 on `engage.py`) 
- We check the string returned by `compare_hashes` on whether the matches include `input_data` and `code` (this is a condition for saving results). Is there a nicer way to do this? (line 101-102 of `engage.py`)

(Note I branched off Eric's approved PR branch).