### PR TITLE
Feature/compare refactor

### DIFF
--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -9,21 +9,13 @@ def compare(args):
     on the command line.
     """
 
+    assert len(args.hashes) == 1 or len(args.hashes) == 2, "compare can only accept 1 or 2 hash files"
+
     hash_dict_1 = ct.load_hash(args.hashes[0])
-    hash_dict_2 = ct.load_hash(args.hashes[1])
-
-    print_comparison(compare_hashes(hash_dict_1, hash_dict_2))
-
-def check_hashes(args):
-    """
-    Checks hash against results
-
-    Checks the values in a provided hash file with the results from hashing the provided locations
-    (input_data, code, and output_data) in the input arguments. Prints results on the command line
-    """
-
-    hash_dict_1 = ct.load_hash(args.hashes)
-    hash_dict_2 = ct.construct_dict(create_timestamp(), args)
+    if len(args.hashes) == 2:
+        hash_dict_2 = ct.load_hash(args.hashes[1])
+    else:
+        hash_dict_2 = ct.construct_dict(create_timestamp(), args)
 
     print_comparison(compare_hashes(hash_dict_1, hash_dict_2))
 

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -12,7 +12,7 @@ def compare(args):
     hash_dict_1 = ct.load_hash(args.hashes[0])
     hash_dict_2 = ct.load_hash(args.hashes[1])
 
-    print(compare_hashes(hash_dict_1, hash_dict_2))
+    print_comparison(compare_hashes(hash_dict_1, hash_dict_2))
 
 def check_hashes(args):
     """
@@ -25,15 +25,16 @@ def check_hashes(args):
     hash_dict_1 = ct.load_hash(args.hashes)
     hash_dict_2 = ct.construct_dict(create_timestamp(), args)
 
-    print(compare_hashes(hash_dict_1, hash_dict_2))
+    print_comparison(compare_hashes(hash_dict_1, hash_dict_2))
 
 def compare_hashes(hash_dict_1, hash_dict_2):
     """
     Compare two hash dictionaries
 
-    Compare two hash dictionaries. Returns a string summarizing the matches (when two hashes are
-    identical), differences (when a hash has been computed for the same entity twice and they
-    are different), and failures (when an entry only exists in one of the two hash dictionaries).
+    Compare two hash dictionaries. Returns a dictionary mapping a string to a list, which
+    summarizes the matches (when two hashes are identical), differences (when a hash has been
+    computed for the same entity twice and they are different), and failures (when an entry
+    only exists in one of the two hash dictionaries).
 
     Parameters
     ----------
@@ -44,7 +45,7 @@ def compare_hashes(hash_dict_1, hash_dict_2):
 
     Returns
     -------
-    str
+    dict {str: list}
     """
 
     get_h = lambda x: list(x.values())[0]
@@ -94,14 +95,30 @@ def compare_hashes(hash_dict_1, hash_dict_2):
             except KeyError:
                 failures.append(out_file)
 
-    return "\n".join([
-        "results differ in {} places:".format(len(differs)),
-        "===========================",
-        *differs,
-        "results match in {} places:".format(len(matches)),
-        "==========================",
-        *matches,
-        "results could not be compared in {} places:".format(len(failures)),
-        "==========================================",
-        *failures
-    ])
+    return { "matches" : matches, "differs" : differs, "failures" : failures }
+
+def print_comparison(compare_dict):
+    """
+    Print a nicely formatted summary of hash comparisons
+
+    Accepts the dictionary output from `compare_hashes` (mapping a string to a list), no return value.
+    """
+
+    try:
+        matches = compare_dict["matches"]
+        differs = compare_dict["differs"]
+        failures = compare_dict["failures"]
+    except KeyError:
+        raise KeyError("comparison dictionary input to print_comparison is missing a value")
+
+    print("\n".join([
+            "results differ in {} places:".format(len(differs)),
+            "===========================",
+            *differs,
+            "results match in {} places:".format(len(matches)),
+            "==========================",
+            *matches,
+            "results could not be compared in {} places:".format(len(failures)),
+            "==========================================",
+            *failures
+            ]))

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -5,7 +5,7 @@ import git
 from git import InvalidGitRepositoryError
 
 from . import catalogue as ct
-from .compare import compare_hashes
+from .compare import compare_hashes, print_comparison
 from .utils import create_timestamp, check_paths_exists
 
 CATALOGUE_DIR = "catalogue_results"
@@ -102,9 +102,9 @@ def disengage(args):
         hash_dict = ct.construct_dict(timestamp, args)
         compare = compare_hashes(hash_dict, lock_dict)
         # check if 'input_data' and 'code' were in matches
-        match_str = compare.split("places")[2]
-        if 'input_data' in match_str and 'code' in match_str:
+        assert "matches" in compare.keys(), "Error in constructing comparison dictionary"
+        if 'input_data' in compare["matches"] and 'code' in compare["matches"]:
             # add engage timestamp to hash_dict
             hash_dict["timestamp"].update({"engage": lock_dict["timestamp"]})
             ct.store_hash(hash_dict, timestamp, CATALOGUE_DIR)
-        print(compare)
+        print_comparison(compare)

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -2,7 +2,7 @@ import argparse
 import textwrap
 
 from .engage import engage, disengage
-from .compare import compare, check_hashes
+from .compare import compare
 
 
 def main():
@@ -30,6 +30,18 @@ def main():
     same as when in `engage` mode (see above). The `output_data` argument should also
     be a string, specifying the directory with the analysis results. The default for
     the `output_data` argument is `"results"` (relative to the current working directory).
+
+    compare
+    -------
+    The `compare` mode is used to check if two hashes are identical, or if the corrent
+    state of the input, code, and output match the state from a previous run. The
+    `compare` mode accepts either 1 or 2 unnamed input arguments which are strings holding the
+    path of existing json files output from the code. If 2 inputs are given, `compare` checks the
+    two inputs, while if 1 input is given that input is compared to the current state.
+    If 1 input is given, the usual flags for input, code, and output paths apply.
+
+    Note that if `compare` mode is used with 1 input, any use of flags to set data or code
+    paths must come before the hash file due to how arguments are parsed.
     """
     parser = argparse.ArgumentParser(
         description="",
@@ -71,15 +83,10 @@ def main():
     )
     engage_parser.set_defaults(func=engage)
 
-    checkhashes_parser = subparsers.add_parser(
-        "checkhashes", parents=[common_parser, output_parser], description="", help=""
-    )
-    checkhashes_parser.set_defaults(func=check_hashes)
-    checkhashes_parser.add_argument("--hashes", type=str, metavar="hashes", help="")
-
-    compare_parser = subparsers.add_parser("compare", description="", help="")
+    compare_parser = subparsers.add_parser("compare", parents=[common_parser, output_parser],
+                                           description="", help="")
     compare_parser.set_defaults(func=compare)
-    compare_parser.add_argument("hashes", type=str, nargs=2, help="")
+    compare_parser.add_argument("hashes", type=str, nargs='+', help="")
 
     disengage_parser = subparsers.add_parser(
         "disengage", parents=[common_parser, output_parser], description="", help=""


### PR DESCRIPTION
Refactors `compare` mode to handle the `check_hashes` case. `compare` now accepts either one or two hash files, and if there is only one then that file is compared with the current state of the directories. Addresses issues #32 and #33.

* Refactor of `compare_hashes` to return a dictionary instead of a string
* `disengage` now more elegantly checks everything
* Function to print out the results of a comparison
* Reworked `compare` mode to handle the `check_hashes` option