### PR TITLE
Refactor tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-shutil

--- a/tests/test_engage.py
+++ b/tests/test_engage.py
@@ -5,11 +5,14 @@ import pytest
 
 from catalogue.engage import engage, disengage
 
-def test_engage(test_args, fixtures_dir, capsys):
+def test_engage(git_repo, test_args, capsys):
+
+    # NOTE: all catalogue_results directory and files are created in CWD
 
     # engage
     engage(test_args)
-    assert os.path.exists(os.path.join("catalogue_results", ".lock"))
+    lock_file = os.path.join("catalogue_results", ".lock")
+    assert os.path.exists(lock_file)
 
     # already engaged
     engage(test_args)
@@ -22,7 +25,8 @@ def test_engage(test_args, fixtures_dir, capsys):
         disengage(test_args)
 
     # disengage
-    setattr(test_args, "output_data", fixtures_dir)
+    results_path = os.path.join(git_repo, "results")
+    setattr(test_args, "output_data", results_path)
     disengage(test_args)
     output_file = glob.glob("catalogue_results/*.json")
     assert len(output_file) == 1
@@ -32,7 +36,7 @@ def test_engage(test_args, fixtures_dir, capsys):
     captured = capsys.readouterr()
     assert "Not currently engaged" in captured.out
 
-    # clean up: delete files
+    # clean up: delete files created in CWD
     os.remove(output_file[0])
     os.rmdir("catalogue_results")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 
 import pytest
-import argparse
 
 from catalogue.utils import check_paths_exists
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,15 @@
 
 import pytest
+import argparse
 
 from catalogue.utils import check_paths_exists
 
 def test_check_paths_exists(test_args):
 
     # valid inputs
-    assert check_paths_exists(test_args) == True
-
-    # some args are ignored, check passes even if value is not a valid path
-    setattr(test_args, "command", "xyz")
+    # (includes arg with value that is not a valid path but that is skipped in check)
     assert check_paths_exists(test_args) == True
 
     # invalid path given
-    setattr(test_args, "input_data", "xyz")
+    setattr(test_args, "output_data", "xyz")
     assert check_paths_exists(test_args) == False


### PR DESCRIPTION
Closes #49 

Summary:
- tests that require a git repo now make use of a new fixture `git_repo` which creates a repo in a temporary workspace
- add `requirements-dev.txt`