### PR TITLE
Make ready for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
+script:
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+  - pip install .
 script:
   - pytest

--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -169,6 +169,7 @@ def hash_output(output_data):
     else:
         raise AssertionError("Provided input {} is not a file or directory".format(output_data))
 
+
 def hash_code(repo_path):
     """
     Get commit digest for current HEAD commit
@@ -231,9 +232,9 @@ def construct_dict(timestamp, args):
     return results
 
 
-def store_hash(hash_dict, timestamp, store):
+def store_hash(hash_dict, timestamp, store, ext="json"):
     """
-    Save hash information to <timestamp.json> file.
+    Save hash information to <timestamp.ext> file.
 
     Parameters
     ----------
@@ -243,17 +244,17 @@ def store_hash(hash_dict, timestamp, store):
         timestamp (will be used as name of file)
     store: str
         directory where to store the file
+    ext: str
+        the extension of the file to store the hash info in, default is "json"
 
     Returns
     -------
     None
     """
-    assert isinstance(timestamp, str)
-    assert len(timestamp) == 15, "bad format for timestamp"
 
-    if not os.path.exists(store):
-        os.makedirs(store)
-    with open(os.path.join(store, "{}.json".format(timestamp)),"w") as f:
+    os.makedirs(store, exist_ok=True)
+    
+    with open(os.path.join(store, "{}.{}".format(timestamp, ext)),"w") as f:
         json.dump(hash_dict, f)
 
 

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -1,6 +1,6 @@
 import os
 from . import catalogue as ct
-from .utils import create_timestamp, CATALOGUE_DIR
+from .utils import create_timestamp
 
 def compare(args):
     """
@@ -16,13 +16,13 @@ def compare(args):
     if args.csv is None:
         hash_dict_1 = ct.load_hash(args.hashes[0])
     else:
-        hash_dict_1 = ct.load_csv(os.path.join(CATALOGUE_DIR, args.csv), args.hashes[0])
+        hash_dict_1 = ct.load_csv(os.path.join(args.catalogue_results, args.csv), args.hashes[0])
 
     if len(args.hashes) == 2:
         if args.csv is None:
             hash_dict_2 = ct.load_hash(args.hashes[1])
         else:
-            hash_dict_2 = ct.load_csv(os.path.join(CATALOGUE_DIR, args.csv), args.hashes[1])
+            hash_dict_2 = ct.load_csv(os.path.join(args.catalogue_results, args.csv), args.hashes[1])
     else:
         hash_dict_2 = ct.construct_dict(create_timestamp(), args)
 

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -28,6 +28,7 @@ def compare(args):
 
     print_comparison(compare_hashes(hash_dict_1, hash_dict_2))
 
+
 def compare_hashes(hash_dict_1, hash_dict_2):
     """
     Compare two hash dictionaries
@@ -98,6 +99,7 @@ def compare_hashes(hash_dict_1, hash_dict_2):
 
     return { "matches" : matches, "differs" : differs, "failures" : failures }
 
+
 def print_comparison(compare_dict):
     """
     Print a nicely formatted summary of hash comparisons
@@ -113,13 +115,15 @@ def print_comparison(compare_dict):
         raise KeyError("comparison dictionary input to print_comparison is missing a value")
 
     print("\n".join([
-            "results differ in {} places:".format(len(differs)),
+            "NOTE we expect the timestamp hashes to differ.",
+            "\nhashes differ in {} places:".format(len(differs)),
             "===========================",
             *differs,
-            "results match in {} places:".format(len(matches)),
+            "\nhashes match in {} places:".format(len(matches)),
             "==========================",
             *matches,
-            "results could not be compared in {} places:".format(len(failures)),
+            "\nhashes could not be compared in {} places:".format(len(failures)),
             "==========================================",
-            *failures
+            *failures,
+            ""
             ]))

--- a/catalogue/compare.py
+++ b/catalogue/compare.py
@@ -6,8 +6,9 @@ def compare(args):
     """
     Compares two hash files
 
-    Compares two hash files, given as input arguments to the command line tool. Prints results
-    on the command line.
+    Compares two hash files, given as input arguments to the command line tool.
+    If only one file is given that input is compared to the current state.
+    Prints results on the command line.
     """
 
     assert len(args.hashes) == 1 or len(args.hashes) == 2, "compare can only accept 1 or 2 hash files"

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -70,6 +70,15 @@ def main():
                              " that is a git repository. Default is the current working directory."),
         default='.')
 
+    common_parser.add_argument(
+        'catalogue_results',
+        type=str,
+        metavar='catalogue_results',
+        help=textwrap.dedent("This argument should be the path (full or relative) to the directory where any" +
+                            " files created by catalogue should be stored. Default is catalogue_results."),
+        default='catalogue_results'
+    )
+
     output_parser = argparse.ArgumentParser(add_help=False)
     output_parser.add_argument(
         '--output_data',

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -11,7 +11,7 @@ def main():
 
     This is the main function that is called when running the tool. The function parses
     the arguments supplied and calls the appropriate function (`engage`, `disengage`,
-    `checkhashes`, or `compare`). The details of each of these functions is described in
+    or `compare`). The details of each of these functions is described in
     the appropriate docstrings.
 
     engage

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -71,7 +71,7 @@ def main():
         default='.')
 
     common_parser.add_argument(
-        'catalogue_results',
+        '--catalogue_results',
         type=str,
         metavar='catalogue_results',
         help=textwrap.dedent("This argument should be the path (full or relative) to the directory where any" +

--- a/catalogue/utils.py
+++ b/catalogue/utils.py
@@ -3,7 +3,6 @@ import os
 
 from datetime import datetime
 
-CATALOGUE_DIR = "catalogue_results"
 
 def create_timestamp():
     return datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -22,6 +21,7 @@ def check_paths_exists(args):
     ---------
     Boolean indicating if all filepaths exist.
     """
-    paths = [value for key, value in vars(args).items() if key not in ["command", "func", "csv"]]
+    paths = [value for key, value in vars(args).items()
+            if key not in ["command", "func", "csv", "catalogue_results"]]
     path_checks = [os.path.exists(path) for path in paths]
     return all(path_checks)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,31 @@
 from setuptools import setup, find_packages
 
+# version information
+MAJOR = 1
+MINOR = 0
+MICRO = 0
+PRERELEASE = 0
+ISRELEASED = True
+version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
+
+if not ISRELEASED:
+    version += ".dev{}".format(PRERELEASE)
+
+# write version information to file
+
+def write_version_file(version):
+    "writes version file that is read when importing version number"
+    version_file = """'''
+Version file automatically created by setup.py file
+'''
+version = '{}'
+    """.format(version)
+
+    with open("catalogue/version.py", "w") as fh:
+        fh.write(version_file)
+
+write_version_file(version)
+
 # Source dependencies from requirements.txt file.
 try:
     with open("requirements.txt", "r") as f:
@@ -10,16 +36,16 @@ except FileNotFoundError:
 
 setup(
     name="catalogue",
-    version="",
+    version=version,
     install_requires=install_packages,
     include_package_data=True,
-    python_requires=">=3.7",
-    author="",
+    python_requires=">=3.6",
+    author='The Alan Turing Institute Research Engineering Group',
     author_email="",
-    url="",
+    url="https://github.com/alan-turing-institute/repro-catalogue",
     # this should be a whitespace separated string of keywords, not a list
     keywords="cli-tool management version-control hashing",
-    description="",
+    description="Tool for reproducible analyses",
     long_description=open("./README.md", "r").read(),
     long_description_content_type="text/markdown",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except FileNotFoundError:
     install_packages = []
 
 setup(
-    name="catalogue",
+    name="repro-catalogue",
     version=version,
     install_requires=install_packages,
     include_package_data=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def fixture4():
 @pytest.fixture
 def empty_hash():
     """
-    Hash produced if no input is provided. 
+    Hash produced if no input is provided.
     """
     return hashlib.sha512().hexdigest()
 
@@ -64,6 +64,7 @@ def test_args(git_repo):
     args = argparse.Namespace(
         command = "engage",
         input_data = os.path.join(git_repo, "data"),
+        catalogue_results = "catalogue_results",
         code = git_repo,
         csv = None
     )

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -215,11 +215,15 @@ def test_store_hash(tmpdir):
     ct.store_hash(hash_dict, timestamp, tmpdir.strpath)
     assert file.read() == '{"hello": "world"}'
 
-    # invalid timestamp
-    with pytest.raises(AssertionError):
-        ct.store_hash(hash_dict, 123456789, tmpdir.strpath)
-    with pytest.raises(AssertionError):
-        ct.store_hash(hash_dict, "20200430", tmpdir.strpath)
+    # save to file in a new subdirectory
+    new_file = tmpdir.join("results", '{}.json'.format(timestamp))
+    ct.store_hash(hash_dict, timestamp, os.path.join(tmpdir.strpath, "results"))
+    assert new_file.read() == '{"hello": "world"}'
+
+    # save to .lock file
+    file = tmpdir.join('.lock')
+    ct.store_hash(hash_dict, "", tmpdir.strpath, ext="lock")
+    assert file.read() == '{"hello": "world"}'
 
     # not all inputs provided
     with pytest.raises(TypeError):

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -16,6 +16,7 @@ def test_compare_json(fixture1, fixture2, fixtures_dir, capsys, git_repo):
         command = "compare",
         input_data = "data",
         output_data = "results",
+        catalogue_results = "catalogue_results",
         code = git_repo,
         csv = None
     )
@@ -68,6 +69,7 @@ def test_compare_csv(fixture4, fixtures_dir, git_repo, workspace, capsys):
         command = "compare",
         input_data = "data",
         output_data = "results",
+        catalogue_results = "catalogue_results",
         code = git_repo,
         csv = fixture4
     )


### PR DESCRIPTION
Summary:
- Closes #17 with versioning now in `setup.py`
- Closes #52 by adding `catalogue_results` argument to the parser which can be used to change where catalogue outputs are stored (otherwise the default value is used) and removing the global `CATALOGUE_DIR` variable.
- Closes #60 by adding `.travis.yml` file
- Includes minor refactor to make use of `store_hash()` in `engage()` 
- Closes #64 by adding message to output of `compare` indicating that different timestamps are expected behaviour

Questions:
- are we happy with the output message of `compare` as is or can it be better?
- any other comments?