### PR TITLE
Give warning if untracked files present

### DIFF
--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -6,6 +6,7 @@ import hashlib
 import git
 from git import InvalidGitRepositoryError, RepositoryDirtyError
 
+
 def hash_file(filepath, m=None):
     '''
     Hash the contents of a file
@@ -170,17 +171,21 @@ def hash_output(output_data):
         raise AssertionError("Provided input {} is not a file or directory".format(output_data))
 
 
-def hash_code(repo_path):
+def hash_code(repo_path, catalogue_dir):
     """
     Get commit digest for current HEAD commit
 
-    Returns the current HEAD commit digest for the code that is run. If the current working
-    directory is not clean, it raises a `RepositoryDirtyError`.
+    Returns the current HEAD commit digest for the code that is run.
+
+    If the current working directory is dirty (or has untracked files other
+    than those held in `catalogue_dir`), it raises a `RepositoryDirtyError`.
 
     Parameters
     ----------
     repo_path: str
         Path to analysis directory git repository.
+    catalogue_dir: str
+        Path to directory with catalogue output files.
 
     Returns
     -------
@@ -193,7 +198,8 @@ def hash_code(repo_path):
     except InvalidGitRepositoryError:
         raise InvalidGitRepositoryError("provided code directory is not a valid git repository")
 
-    if repo.is_dirty():
+    untracked = [f for f in repo.untracked_files if catalogue_dir not in f]
+    if repo.is_dirty() or len(untracked) != 0:
         raise RepositoryDirtyError(repo, "git repository contains uncommitted changes")
 
     return repo.head.commit.hexsha
@@ -223,7 +229,7 @@ def construct_dict(timestamp, args):
             args.input_data : hash_input(args.input_data)
         },
         "code": {
-            args.code : hash_code(args.code)
+            args.code : hash_code(args.code, args.catalogue_results)
         }
     }
     if hasattr(args, 'output_data'):
@@ -253,7 +259,7 @@ def store_hash(hash_dict, timestamp, store, ext="json"):
     """
 
     os.makedirs(store, exist_ok=True)
-    
+
     with open(os.path.join(store, "{}.{}".format(timestamp, ext)),"w") as f:
         json.dump(hash_dict, f)
 

--- a/catalogue/catalogue.py
+++ b/catalogue/catalogue.py
@@ -5,6 +5,7 @@ from itertools import chain
 import hashlib
 import git
 from git import InvalidGitRepositoryError, RepositoryDirtyError
+from .utils import prune_files
 
 
 def hash_file(filepath, m=None):
@@ -198,7 +199,7 @@ def hash_code(repo_path, catalogue_dir):
     except InvalidGitRepositoryError:
         raise InvalidGitRepositoryError("provided code directory is not a valid git repository")
 
-    untracked = [f for f in repo.untracked_files if catalogue_dir not in f]
+    untracked = prune_files(repo.untracked_files, catalogue_dir)
     if repo.is_dirty() or len(untracked) != 0:
         raise RepositoryDirtyError(repo, "git repository contains uncommitted changes")
 

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -6,7 +6,7 @@ from git import InvalidGitRepositoryError
 
 from . import catalogue as ct
 from .compare import compare_hashes, print_comparison
-from .utils import create_timestamp, check_paths_exists
+from .utils import create_timestamp, check_paths_exists, prune_files
 
 
 def git_query(repo_path, catalogue_dir, commit_changes=False):
@@ -46,7 +46,7 @@ def git_query(repo_path, catalogue_dir, commit_changes=False):
     except InvalidGitRepositoryError:
         raise InvalidGitRepositoryError("provided code directory is not a valid git repository")
 
-    untracked = [f for f in repo.untracked_files if catalogue_dir not in f]
+    untracked = prune_files(repo.untracked_files, catalogue_dir)
 
     if repo.is_dirty() or (len(untracked) != 0):
         if commit_changes:

--- a/catalogue/engage.py
+++ b/catalogue/engage.py
@@ -9,26 +9,29 @@ from .compare import compare_hashes, print_comparison
 from .utils import create_timestamp, check_paths_exists
 
 
-def git_query(repo_path, commit_changes=False):
+def git_query(repo_path, catalogue_dir, commit_changes=False):
     """
     Check status of a git repository
 
     Checks the git status of the repository on the provided path
     - if clean, returns true
-    - if there are uncommitted changes, and the `commit_changes` flag is
-        `True`, ask for the users offer to stage and commit all and continue
-        (returning `True`)
+    - if there are uncommitted changes (including untracked files other than
+        those held in `catalogue_dir`), and the `commit_changes` flag is
+        `True`, offer the user to stage and commit all tracked (and untracked)
+        files and continue (returns `True`)
         otherwise, returns `False`
 
     If the `commit_changes` flag is `True` and the user accepts the offer
     to commit changes, a new branch is created with the name
     `"catalogue-%Y%m%d-%H%M%S"` and all tracked files that have been
-    changed will be staged and committed.
+    changed & any untracked files will be staged and committed.
 
     Parameters:
     ------------
     repo_path : str
         path to the code directory
+    catalogue_dir : str
+        path to directory with catalogue output files
     commit_changes : bool
         boolean indicating if the user should be prompted to stage and commit changes
         (optional, default is False)
@@ -43,7 +46,9 @@ def git_query(repo_path, commit_changes=False):
     except InvalidGitRepositoryError:
         raise InvalidGitRepositoryError("provided code directory is not a valid git repository")
 
-    if repo.is_dirty():
+    untracked = [f for f in repo.untracked_files if catalogue_dir not in f]
+
+    if repo.is_dirty() or (len(untracked) != 0):
         if commit_changes:
             print("Working directory contains uncommitted changes.")
             print("Do you want to stage and commit all changes? (y/[n])")
@@ -53,6 +58,7 @@ def git_query(repo_path, commit_changes=False):
                 new_branch = repo.create_head("catalogue-" + timestamp)
                 new_branch.checkout()
                 changed_files = [ item.a_path for item in repo.index.diff(None) ]
+                changed_files.extend(untracked)
                 repo.index.add(changed_files)
                 repo.index.commit("repro-catalogue tool auto commit at " + timestamp)
                 return True
@@ -76,15 +82,25 @@ def engage(args):
 
     The engage command:
         - does a `git_query()` check of the `code` repo
+            (engage does not proceed unless the repo is clean)
         - gets hashes for the input_data and code (from `construct_dict()`)
         - saves the hashes to a `.lock` file
 
     Once engaged (a `.lock` file exists), the command cannot be run again until
     `disengage` has been run.
+
+    Parameters:
+    ------------
+    args : obj
+        Command line input arguments (argparse.Namespace).
+
+    Returns:
+    ---------
+    None
     """
     assert check_paths_exists(args), 'Not all provided filepaths exist.'
 
-    if git_query(args.code, True):
+    if git_query(args.code, args.catalogue_results, True):
         try:
             assert not os.path.exists(os.path.join(args.catalogue_results, ".lock"))
         except AssertionError:
@@ -108,8 +124,18 @@ def disengage(args):
     The disengage command:
         - reads hashes stored in the `.lock` file created during `engage`
         - gets hashes for the `input_data`, `code` and `output_data` (from `construct_dict()`)
-        - compares the two sets of hashes (if the same, saves the hashes)
+        - compares the two sets of hashes
+            (if `input_data` and `code` hashes match, saves the hashes to a file)
         - prints the results of the comparison
+
+    Parameters:
+    ------------
+    args : obj
+        Command line input arguments (argparse.Namespace).
+
+    Returns:
+    ---------
+    None
     """
     assert check_paths_exists(args), 'Not all provided filepaths exist.'
 

--- a/catalogue/parser.py
+++ b/catalogue/parser.py
@@ -75,7 +75,8 @@ def main():
         type=str,
         metavar='catalogue_results',
         help=textwrap.dedent("This argument should be the path (full or relative) to the directory where any" +
-                            " files created by catalogue should be stored. Default is catalogue_results."),
+                            " files created by catalogue should be stored. It cannot be the same as the `code`" +
+                            " directory. Default is catalogue_results."),
         default='catalogue_results'
     )
 
@@ -116,7 +117,9 @@ def main():
     disengage_parser.set_defaults(func=disengage)
 
     args = parser.parse_args()
+    assert args.code != args.catalogue_results, "The 'catalogue_results' and 'code' paths cannot be the same"
     args.func(args)
+
 
 if __name__ == "__main__":
     main()

--- a/catalogue/utils.py
+++ b/catalogue/utils.py
@@ -25,3 +25,21 @@ def check_paths_exists(args):
             if key not in ["command", "func", "csv", "catalogue_results"]]
     path_checks = [os.path.exists(path) for path in paths]
     return all(path_checks)
+
+
+def prune_files(files, dir):
+    """
+    Return files that do not have `dir` as last directory in the file path.
+
+    Parameters:
+    ------------
+    files : list of str
+        list of file paths
+    dir : str
+        directory name, files in this directory are removed
+
+    Returns:
+    ---------
+    list of str
+    """
+    return [f for f in files if dir != os.path.basename(os.path.dirname(f))]

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -137,22 +137,22 @@ def test_hash_output(fixtures_dir, copy_fixtures_dir, fixture1, fixture2, fixtur
 def test_hash_code(git_repo, git_hash, workspace):
 
     # correct functioning
-    assert ct.hash_code(git_repo) == git_hash
+    assert ct.hash_code(git_repo, 'catalogue_results') == git_hash
 
     # directory has uncommited file
     workspace.run("touch test.csv")
     workspace.run("git add .")
     with pytest.raises(RepositoryDirtyError):
-        ct.hash_code(git_repo)
+        ct.hash_code(git_repo, 'catalogue_results')
 
-    # invalid path
+    # missing arguments
     with pytest.raises(TypeError):
         ct.hash_code()
 
     # path not a git repo
     workspace.run("rm -rf .git")
     with pytest.raises(InvalidGitRepositoryError):
-        ct.hash_code(git_repo)
+        ct.hash_code(git_repo, 'catalogue_results')
 
 
 def test_construct_dict(git_repo, git_hash, test_args):

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -144,8 +144,9 @@ def test_hash_code(git_repo, git_hash, workspace):
     workspace.run("touch catalogue_results/test.csv")
     assert ct.hash_code(git_repo, 'catalogue_results') == git_hash
 
-    # directory has untracked file
-    workspace.run("touch test.csv")
+    # directory has untracked file; file path includes `catalogue_results` but
+    # it is not the directory name
+    workspace.run("touch catalogue_results.csv")
     with pytest.raises(RepositoryDirtyError):
         ct.hash_code(git_repo, 'catalogue_results')
 

--- a/tests/test_engage.py
+++ b/tests/test_engage.py
@@ -44,8 +44,10 @@ def test_git_query(git_repo, capsys, workspace, monkeypatch):
     # repo is clean
     assert git_query(git_repo, catalogue_results, True) == True
 
-    # create new file -- untracked --> wil ask for user input
+    # create new file (untracked) --> wil ask for user input
     workspace.run("touch test2.csv")
+
+    # user responds no
     monkeypatch.setattr('builtins.input', lambda: "n")
     assert git_query(git_repo, catalogue_results, True) == False
 

--- a/tests/test_engage.py
+++ b/tests/test_engage.py
@@ -22,8 +22,9 @@ def test_git_query(git_repo, capsys, workspace, monkeypatch):
     # repo is clean
     assert git_query(git_repo, catalogue_results) == True
 
-    # create new file -- untracked
-    workspace.run("touch test.csv")
+    # create new file -- untracked; file path includes `catalogue_results` but
+    # it is not the directory name
+    workspace.run("touch catalogue_results.json")
     assert git_query(git_repo, catalogue_results) == False
 
     # git add file without commit
@@ -36,6 +37,11 @@ def test_git_query(git_repo, capsys, workspace, monkeypatch):
     assert git_hash_0 != git_hash_1
     assert git_query(git_repo, catalogue_results) == True
 
+    # create new file in `catalogue_results` dir
+    workspace.run("mkdir catalogue_results")
+    workspace.run("touch catalogue_results/test.json")
+    assert git_query(git_repo, catalogue_results) == True
+
     #==================================================
     # 2: use with commit_changes=True
     # --> user will get asked to commit changes
@@ -45,7 +51,8 @@ def test_git_query(git_repo, capsys, workspace, monkeypatch):
     assert git_query(git_repo, catalogue_results, True) == True
 
     # create new file (untracked) --> wil ask for user input
-    workspace.run("touch test2.csv")
+    # file path includes `catalogue_results` but it is not the directory name
+    workspace.run("touch new_catalogue_results.json")
 
     # user responds no
     monkeypatch.setattr('builtins.input', lambda: "n")


### PR DESCRIPTION
Closes #44

Updates functionality so that untracked files raise a warning (unless those files are in the `catalogue_results` directory).